### PR TITLE
Adding submit_resource_free function for vulkan context

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -399,12 +399,11 @@ main() {
         test_uniforms[i].destroy();
     }
 
-    test_descriptor_sets.destroy();
-    // test_index_buffer.destroy();
-    // test_vertex_buffer.destroy();
-    new_mesh.destroy();
-    test_pipeline.destroy();
-    test_shader.destroy();
-    main_window_swapchain.destroy();
-    main_driver.destroy();
+    // test_descriptor_sets.destroy();
+    // new_mesh.destroy();
+    // test_pipeline.destroy();
+    // test_shader.destroy();
+    // main_window_swapchain.destroy();
+    // main_driver.destroy();
+    initiating_vulkan.cleanup();
 }

--- a/src/renderer/mesh.cpp
+++ b/src/renderer/mesh.cpp
@@ -3,6 +3,7 @@
 #include <tiny_obj_loader.h>
 #include <vulkan-cpp/logger.hpp>
 #include <vulkan-cpp/vk_vertex_buffer.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
     mesh::mesh(const std::span<vertex>& p_vertices,
@@ -87,6 +88,13 @@ namespace vk {
 
         m_vbo = vk_vertex_buffer(vertices);
         m_ibo = vk_index_buffer(indices);
+
+
+
+        vk_context::submit_resource_free([this](){
+            m_vbo.destroy();
+            m_ibo.destroy();
+        });
     }
 
     void mesh::set_texture(uint32_t p_index, const std::string& p_filename) {
@@ -108,8 +116,6 @@ namespace vk {
     }
 
     void mesh::destroy() {
-        m_vbo.destroy();
-        m_ibo.destroy();
 
         // for(size_t i = 0; i < m_textures.size(); i++) {
         //     m_textures[i].destroy();

--- a/src/vulkan-cpp/vk_context.cpp
+++ b/src/vulkan-cpp/vk_context.cpp
@@ -108,8 +108,19 @@ namespace vk {
         // vkDestroyInstance(m_instance, nullptr);
     }
 
+    void vk_context::submit_resource_free(const std::function<void()>& p_callable) {
+        s_instance->resource_free(p_callable);
+    }
+
+    void vk_context::resource_free(const std::function<void()>& p_callable) {
+        m_resource_to_free.push_front(p_callable);
+    }
+
     void vk_context::cleanup() {
-        vkDestroyInstance(m_instance, nullptr);
+        for(auto& callable : m_resource_to_free) {
+            callable();
+        }
+        // vkDestroyInstance(m_instance, nullptr);
     }
 
 };

--- a/src/vulkan-cpp/vk_descriptor_set.cpp
+++ b/src/vulkan-cpp/vk_descriptor_set.cpp
@@ -4,6 +4,7 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
 #include <span>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
 
@@ -98,7 +99,12 @@ namespace vk {
                                           m_descriptor_sets.data()),
                  "vkAllocateDescriptorSets",
                  __FUNCTION__);
+        vk_context::submit_resource_free([this](){
+            vkDestroyDescriptorPool(m_driver, m_descriptor_pool, nullptr);
+            vkDestroyDescriptorSetLayout(m_driver, m_descriptor_set_layout, nullptr);
+        });
     }
+
 
     void vk_descriptor_set::bind(const VkCommandBuffer& p_command_buffer,
                                  uint32_t p_frame_index,
@@ -317,8 +323,7 @@ namespace vk {
     }
 
     void vk_descriptor_set::destroy() {
-        vkDestroyDescriptorPool(m_driver, m_descriptor_pool, nullptr);
-        vkDestroyDescriptorSetLayout(
-          m_driver, m_descriptor_set_layout, nullptr);
+        // vkDestroyDescriptorPool(m_driver, m_descriptor_pool, nullptr);
+        // vkDestroyDescriptorSetLayout(m_driver, m_descriptor_set_layout, nullptr);
     }
 };

--- a/src/vulkan-cpp/vk_driver.cpp
+++ b/src/vulkan-cpp/vk_driver.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <vulkan-cpp/logger.hpp>
 #include <vulkan-cpp/helper_functions.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
 
@@ -107,6 +108,13 @@ namespace vk {
         console_log_info("vk_driver::vk_driver end initialization!!!\n\n");
 
         s_instance = this;
+
+		
+		vk_context::submit_resource_free([this](){
+			console_log_fatal("vk_driver resource freed");
+			vkDestroyDevice(m_driver, nullptr);
+		});
+
     }
 
     VkFormat vk_driver::depth_format() {
@@ -116,7 +124,7 @@ namespace vk {
     vk_driver::~vk_driver() {}
 
     void vk_driver::destroy() {
-        vkDestroyDevice(m_driver, nullptr);
+        // vkDestroyDevice(m_driver, nullptr);
     }
 
     VkQueue vk_driver::get_presentation_queue(

--- a/src/vulkan-cpp/vk_index_buffer.cpp
+++ b/src/vulkan-cpp/vk_index_buffer.cpp
@@ -2,6 +2,7 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
     vk_index_buffer::vk_index_buffer(const std::span<uint32_t>& p_indices) {
@@ -24,6 +25,11 @@ namespace vk {
         write(m_index_buffer_data, p_indices);
 
         console_log_info("vk_index_buffer end initialization successfully!!!!");
+
+        // vk_context::submit_resource_free([this](){
+        //     vkFreeMemory(m_driver, m_index_buffer_data.DeviceMemory, nullptr);
+        //     vkDestroyBuffer(m_driver, m_index_buffer_data.BufferHandler, nullptr);
+        // });
     }
 
     void vk_index_buffer::bind(const VkCommandBuffer& p_command_buffer) {

--- a/src/vulkan-cpp/vk_pipeline.cpp
+++ b/src/vulkan-cpp/vk_pipeline.cpp
@@ -5,6 +5,7 @@
 #include <vulkan-cpp/vk_driver.hpp>
 #include <vulkan-cpp/vk_window.hpp>
 #include <vulkan/vulkan_core.h>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
     vk_pipeline::vk_pipeline(
@@ -244,15 +245,24 @@ namespace vk {
           __FUNCTION__);
 
         console_log_info("vk_pipeline successfully initialized!!!!\n\n");
+
+        vk_context::submit_resource_free([this](){
+            console_log_fatal("vk_pipeline resource freed");
+            vkDestroyPipelineLayout(m_driver, m_pipeline_layout, nullptr);
+            vkDestroyPipeline(m_driver, m_pipeline, nullptr);
+
+            m_pipeline_layout = VK_NULL_HANDLE;
+            m_pipeline = VK_NULL_HANDLE;
+        });
     }
 
     void vk_pipeline::destroy() {
-        vkDeviceWaitIdle(m_driver);
-        vkDestroyPipelineLayout(m_driver, m_pipeline_layout, nullptr);
-        vkDestroyPipeline(m_driver, m_pipeline, nullptr);
+        // vkDeviceWaitIdle(m_driver);
+        // vkDestroyPipelineLayout(m_driver, m_pipeline_layout, nullptr);
+        // vkDestroyPipeline(m_driver, m_pipeline, nullptr);
 
-        m_pipeline_layout = VK_NULL_HANDLE;
-        m_pipeline = VK_NULL_HANDLE;
+        // m_pipeline_layout = VK_NULL_HANDLE;
+        // m_pipeline = VK_NULL_HANDLE;
     }
 
     void vk_pipeline::bind(const VkCommandBuffer& p_command_buffer) {

--- a/src/vulkan-cpp/vk_shader.cpp
+++ b/src/vulkan-cpp/vk_shader.cpp
@@ -6,6 +6,8 @@
 #include <fmt/ranges.h>
 #include <shaderc/shaderc.hpp>
 #include <shader_compiler/shader_compiler.hpp>
+#include <vulkan-cpp/vk_context.hpp>
+
 
 namespace vk {
 
@@ -176,6 +178,16 @@ namespace vk {
         }
 
         compile(p_vert_filename, p_frag_filename);
+
+
+        vk_context::submit_resource_free([this](){
+            console_log_fatal("vk_shader resource freed");
+            vkDestroyShaderModule(m_driver, m_vertex_shader_module, nullptr);
+            vkDestroyShaderModule(m_driver, m_fragment_shader_module, nullptr);
+
+            m_vertex_shader_module = VK_NULL_HANDLE;
+            m_fragment_shader_module = VK_NULL_HANDLE;
+        });
 
     }
 

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -1,6 +1,7 @@
 #include <vulkan-cpp/vk_swapchain.hpp>
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
     vk_swapchain* vk_swapchain::s_instance = nullptr;
@@ -121,6 +122,43 @@ namespace vk {
       , m_current_surface(p_surface) {
         m_surface_data = p_physical.get_surface_properties(p_surface);
         on_create();
+
+
+		vk_context::submit_resource_free([this](){
+			console_log_fatal("vk_swapchain resource freed");
+			// needed to be called to ensure all children objects are executed just
+			// before they get destroyed!! vkDeviceWaitIdle(m_driver);
+
+			for (size_t i = 0; i < m_swapchain_framebuffers.size(); i++) {
+				vkDestroyFramebuffer(
+				m_driver, m_swapchain_framebuffers[i], nullptr);
+			}
+
+			vkDestroyRenderPass(m_driver, m_swapchain_renderpass, nullptr);
+
+			m_swapchain_present_queue.destroy();
+
+			// vkDestroyCommandPool(m_driver, m_command_pool, nullptr);
+			for (size_t i = 0; i < m_swapchain_command_buffers.size(); i++) {
+				m_swapchain_command_buffers[i].destroy();
+			}
+
+			for (uint32_t i = 0; i < m_swapchain_depth_images.size(); i++) {
+				vkDestroyImageView(
+				m_driver, m_swapchain_depth_images[i].ImageView, nullptr);
+				vkDestroyImage(
+				m_driver, m_swapchain_depth_images[i].Image, nullptr);
+				vkFreeMemory(
+				m_driver, m_swapchain_depth_images[i].DeviceMemory, nullptr);
+			}
+
+			for (uint32_t i = 0; i < m_swapchain_images.size(); i++) {
+				vkDestroyImageView(
+				m_driver, m_swapchain_images[i].ImageView, nullptr);
+			}
+
+			vkDestroySwapchainKHR(m_driver, m_swapchain_handler, nullptr);
+		});
     }
 
     void vk_swapchain::on_create() {
@@ -355,38 +393,38 @@ namespace vk {
 
     void vk_swapchain::destroy() {
 
-        // needed to be called to ensure all children objects are executed just
-        // before they get destroyed!! vkDeviceWaitIdle(m_driver);
+        // // needed to be called to ensure all children objects are executed just
+        // // before they get destroyed!! vkDeviceWaitIdle(m_driver);
 
-        for (size_t i = 0; i < m_swapchain_framebuffers.size(); i++) {
-            vkDestroyFramebuffer(
-              m_driver, m_swapchain_framebuffers[i], nullptr);
-        }
+        // for (size_t i = 0; i < m_swapchain_framebuffers.size(); i++) {
+        //     vkDestroyFramebuffer(
+        //       m_driver, m_swapchain_framebuffers[i], nullptr);
+        // }
 
-        vkDestroyRenderPass(m_driver, m_swapchain_renderpass, nullptr);
+        // vkDestroyRenderPass(m_driver, m_swapchain_renderpass, nullptr);
 
-        m_swapchain_present_queue.destroy();
+        // m_swapchain_present_queue.destroy();
 
-        // vkDestroyCommandPool(m_driver, m_command_pool, nullptr);
-        for (size_t i = 0; i < m_swapchain_command_buffers.size(); i++) {
-            m_swapchain_command_buffers[i].destroy();
-        }
+        // // vkDestroyCommandPool(m_driver, m_command_pool, nullptr);
+        // for (size_t i = 0; i < m_swapchain_command_buffers.size(); i++) {
+        //     m_swapchain_command_buffers[i].destroy();
+        // }
 
-        for (uint32_t i = 0; i < m_swapchain_depth_images.size(); i++) {
-            vkDestroyImageView(
-              m_driver, m_swapchain_depth_images[i].ImageView, nullptr);
-            vkDestroyImage(
-              m_driver, m_swapchain_depth_images[i].Image, nullptr);
-            vkFreeMemory(
-              m_driver, m_swapchain_depth_images[i].DeviceMemory, nullptr);
-        }
+        // for (uint32_t i = 0; i < m_swapchain_depth_images.size(); i++) {
+        //     vkDestroyImageView(
+        //       m_driver, m_swapchain_depth_images[i].ImageView, nullptr);
+        //     vkDestroyImage(
+        //       m_driver, m_swapchain_depth_images[i].Image, nullptr);
+        //     vkFreeMemory(
+        //       m_driver, m_swapchain_depth_images[i].DeviceMemory, nullptr);
+        // }
 
-        for (uint32_t i = 0; i < m_swapchain_images.size(); i++) {
-            vkDestroyImageView(
-              m_driver, m_swapchain_images[i].ImageView, nullptr);
-        }
+        // for (uint32_t i = 0; i < m_swapchain_images.size(); i++) {
+        //     vkDestroyImageView(
+        //       m_driver, m_swapchain_images[i].ImageView, nullptr);
+        // }
 
-        vkDestroySwapchainKHR(m_driver, m_swapchain_handler, nullptr);
+        // vkDestroySwapchainKHR(m_driver, m_swapchain_handler, nullptr);
     }
 
     void vk_swapchain::resize(uint32_t p_width, uint32_t p_height) {

--- a/src/vulkan-cpp/vk_uniform_buffer.cpp
+++ b/src/vulkan-cpp/vk_uniform_buffer.cpp
@@ -2,6 +2,7 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
 
@@ -31,8 +32,7 @@ namespace vk {
         // }
         m_uniform_buffer_data = create_uniform_buffer(p_size_in_bytes);
 
-        console_log_info(
-          "vk_uniform_buffer successfully finished initialization!!!\n\n");
+        console_log_info("vk_uniform_buffer successfully finished initialization!!!\n\n");
     }
 
     VkBuffer vk_uniform_buffer::get(uint32_t p_frame_index) {

--- a/src/vulkan-cpp/vk_vertex_buffer.cpp
+++ b/src/vulkan-cpp/vk_vertex_buffer.cpp
@@ -3,6 +3,7 @@
 #include <vulkan/vulkan.h>
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan-cpp/vk_context.hpp>
 
 namespace vk {
 
@@ -45,6 +46,14 @@ namespace vk {
         vkFreeMemory(m_driver, staging_buffer.DeviceMemory, nullptr);
         vkDestroyBuffer(m_driver, staging_buffer.BufferHandler, nullptr);
         console_log_trace("vertex buffer end initialization!!!");
+
+        // vk_context::submit_resource_free([this](){
+        //     // console_log_fatal("vk_vertex_buffer resource freed");
+        //     vkFreeMemory(m_driver, m_vertex_data.DeviceMemory, nullptr);
+        //     vkDestroyBuffer(m_driver, m_vertex_data.BufferHandler, nullptr);
+        //     m_vertex_data.AllocateDeviceSize = 0;
+        //     m_vertex_data = {};
+        // });
     }
 
     // void vk_vertex_buffer::copy(const VkCommandBuffer& p_command_buffer) {}

--- a/vulkan-cpp/vk_context.hpp
+++ b/vulkan-cpp/vk_context.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 #include <vulkan/vulkan.hpp>
+#include <functional>
+#include <deque>
 
 namespace vk {
     class vk_context {
@@ -14,10 +16,16 @@ namespace vk {
 
         static VkInstance current_context() { return *s_instance; }
 
+        static void submit_resource_free(const std::function<void()>& p_callable);
+
         void cleanup();
 
     private:
+        void resource_free(const std::function<void()>& p_callable);
+
+    private:
         static vk_context* s_instance;
+        std::deque<std::function<void()>> m_resource_to_free;
         VkInstance m_instance = nullptr;
     };
 };


### PR DESCRIPTION
Added submit_resource_free function to ensure vulkan child objects are deallocated before logical devices get deallocated