### PR TITLE
Swapchain recreation

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -351,7 +351,7 @@ main() {
 
         // Start recording
         main_window_swapchain.begin(current);
-        test_imgui.begin();
+        //test_imgui.begin();
 
 
         test_pipeline.bind(current);
@@ -360,16 +360,16 @@ main() {
         // draw (after recording)
         new_mesh.draw(current);
 
-        ImGui::Begin("Viewport");
-        ImGui::Button("Texture Image 0");
+        //ImGui::Begin("Viewport");
+        //ImGui::Button("Texture Image 0");
 
         // ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
         // ImGui::Image(test_descriptor_sets.get(frame), ImVec2{100, 100});
 
         // ImGui::Image()
-        ImGui::End();
+        //ImGui::End();
 
-        test_imgui.end(current);
+        //test_imgui.end(current);
         main_window_swapchain.end(current);
 
         //! @note This submits the command buffer and also presents the command buffer as well

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,13 +22,12 @@ class StarterConanRecipe(ConanFile):
     # Putting all of your packages here
     def requirements(self):
       self.requires("glfw/3.4")
-      self.requires("fmt/10.2.1")
       self.requires("glm/1.0.1", transitive_headers=True)
       self.requires("imguidocking/2.0", transitive_headers=True)
       self.requires("watcher/0.12.0")
       self.requires("vulkan-headers/1.3.290.0")
       self.requires("stb/cci.20230920")
-      self.requires("spdlog/1.14.1", transitive_headers=True)
+      self.requires("spdlog/1.15.1", transitive_headers=True)
       # self.requires("spirv-cross/1.4.309.0")
       self.requires("flecs/4.0.0")
       self.requires("tinyobjloader/2.0.0-rc10")

--- a/imgui.ini
+++ b/imgui.ini
@@ -10,7 +10,7 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-ViewportPos=1212,252
+ViewportPos=2280,422
 ViewportId=0x995B0CF8
 Size=367,498
 Collapsed=0

--- a/src/vulkan-cpp/helper_functions.cpp
+++ b/src/vulkan-cpp/helper_functions.cpp
@@ -1,8 +1,6 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
-#include <vulkan/vulkan.hpp>
-#include <vulkan/vulkan_enums.hpp>
 
 
 namespace vk {
@@ -642,7 +640,7 @@ namespace vk {
                                      p_line,
                                      p_function_name);
             console_log_error_tagged(
-              "vulkan", "VkResult returned: {} ({})", (int)result, to_string((vk::Result)result));
+              "vulkan", "VkResult returned: {}", (int)result);
         }
     }
 

--- a/src/vulkan-cpp/helper_functions.cpp
+++ b/src/vulkan-cpp/helper_functions.cpp
@@ -1,6 +1,9 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_enums.hpp>
+
 
 namespace vk {
 
@@ -639,7 +642,7 @@ namespace vk {
                                      p_line,
                                      p_function_name);
             console_log_error_tagged(
-              "vulkan", "VkResult returned: {}", (int)result);
+              "vulkan", "VkResult returned: {} ({})", (int)result, to_string((vk::Result)result));
         }
     }
 

--- a/src/vulkan-cpp/vk_queue.cpp
+++ b/src/vulkan-cpp/vk_queue.cpp
@@ -1,6 +1,7 @@
 #include <vulkan-cpp/vk_queue.hpp>
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan/vulkan_core.h>
 
 namespace vk {
     static VkSemaphore create_semaphore(const VkDevice& p_driver) {
@@ -76,9 +77,11 @@ namespace vk {
                                           .swapchainCount = 1,
                                           .pSwapchains = &m_swapchain_handler,
                                           .pImageIndices = &p_frame_index };
-        vk_check(vkQueuePresentKHR(m_queue, &present_info),
-                 "vkQueuePresentKHR",
-                 __FUNCTION__);
+        VkResult queue_present_result = vkQueuePresentKHR(m_queue, &present_info);
+        if (queue_present_result == VK_ERROR_OUT_OF_DATE_KHR || queue_present_result ==  VK_SUBOPTIMAL_KHR) {
+            console_log_info("{} -- Swapchain out of date!! Attempting recreation.....", __FUNCTION__);
+            m_resize_requested = true;
+        }
     }
 
     void vk_queue::wait_idle() {
@@ -97,6 +100,7 @@ namespace vk {
         
         m_status = acquired_next_image_result;
         if(acquired_next_image_result == VK_ERROR_OUT_OF_DATE_KHR) {
+            console_log_info("{} -- Swapchain out of date!! Attempting recreation....", __FUNCTION__);
             m_resize_requested = true;
         }
 

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -1,6 +1,7 @@
 #include <vulkan-cpp/vk_swapchain.hpp>
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan/vulkan_core.h>
 
 namespace vk {
     vk_swapchain* vk_swapchain::s_instance = nullptr;
@@ -125,8 +126,9 @@ namespace vk {
 
     void vk_swapchain::on_create() {
         console_log_info("vk_swapchain() begin initialization!!!");
+        m_surface_data = m_physical.get_surface_properties(m_current_surface);
         m_swapchain_size = m_surface_data.SurfaceCapabilities.currentExtent;
-
+        console_log_info("Extent data: {} {}", m_swapchain_size.width, m_swapchain_size.height);
         // request what our minimum image count is
         uint32_t request_min_image_count =
           select_images_size(m_surface_data.SurfaceCapabilities);
@@ -278,6 +280,8 @@ namespace vk {
 
     void vk_swapchain::recreate() {
         vkDeviceWaitIdle(m_driver);
+        console_log_info("Started: {}", __FUNCTION__);
+        destroy();
         on_create();
     }
 
@@ -340,7 +344,17 @@ namespace vk {
 	uint32_t vk_swapchain::read_acquired_frame() {
 		//! @note We always want to wait until the current frame is ready before moving onto the next frame
 		m_swapchain_present_queue.wait_idle();
+        
+        if (m_swapchain_present_queue.is_resize_requested()) {
+            recreate();
+            m_swapchain_present_queue.set_resize_completed();
+        }
 		uint32_t current_frame = m_swapchain_present_queue.read_acquire_image();
+
+        if (m_swapchain_present_queue.is_resize_requested()) {
+            recreate();
+            m_swapchain_present_queue.set_resize_completed();
+        }
 		m_current_image_index = current_frame;
 		return current_frame;
 	}
@@ -356,7 +370,7 @@ namespace vk {
     void vk_swapchain::destroy() {
 
         // needed to be called to ensure all children objects are executed just
-        // before they get destroyed!! vkDeviceWaitIdle(m_driver);
+        // before they get destroyed!! vkDeviceWaitIdle(m_driver)
 
         for (size_t i = 0; i < m_swapchain_framebuffers.size(); i++) {
             vkDestroyFramebuffer(

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -349,12 +349,9 @@ namespace vk {
             recreate();
             m_swapchain_present_queue.set_resize_completed();
         }
+
 		uint32_t current_frame = m_swapchain_present_queue.read_acquire_image();
 
-        if (m_swapchain_present_queue.is_resize_requested()) {
-            recreate();
-            m_swapchain_present_queue.set_resize_completed();
-        }
 		m_current_image_index = current_frame;
 		return current_frame;
 	}

--- a/src/vulkan-cpp/vk_vertex_buffer.cpp
+++ b/src/vulkan-cpp/vk_vertex_buffer.cpp
@@ -35,7 +35,6 @@ namespace vk {
         // 2. Mapping memory of vertex buffer (vkMap/vkUnmap operation)
         write(staging_buffer, p_vertices);
 
-
         // m_vertex_data = create_buffer(m_vertices_byte_size_count, usage, memory_property_flags);
         m_vertex_data = create_buffer(m_vertices_byte_size_count, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 

--- a/vulkan-cpp/vk_queue.hpp
+++ b/vulkan-cpp/vk_queue.hpp
@@ -22,7 +22,7 @@ namespace vk {
         uint32_t read_acquire_image();
 
         bool is_resize_requested() const { return m_resize_requested; }
-        void set_resize_request(const bool& p_request) { m_resize_requested = p_request; }
+        void set_resize_completed() { m_resize_requested = false; }
         VkResult queue_acquired_image_status() const { return m_status; }
         /*
         Specify whether you want to submit to the command buffer in either async


### PR DESCRIPTION
## Brief

Updated the vulkan renderer to allow for swapchain recreation in the case that the existing swapchain becomes invalid or unoptimized. This is mainly implemented for window resizing, which now works save for fully minimizing the window.

Additionally, I temporarily stopped the ImGUI rendering for the momemt since it was causing validation errors unrelated to the swapchain resizing issue  -- this is something to look into...

One other minor (slightly out of scope) change that I  did was making the output of vk_check slightly more readable by actually printing the VkResult enum field names rather then just the numerical value
## Changelog
* Updated ```vk_queue``` to detect swap chain invalidation upon ```vkQueuePresentKHR``` and ```vkAcquireSwapchainImageKHR``` and recreate the swapchain accordingly
* Added small additional logging to ```vk_check``` which displays stringified ```VkResult``` enum value on non ```VK_SUCCESS``` return. (This displays in addition to what is already there)
* Temporarily disabled ImGUI rendering as it was causing additional validation errors
## Next Steps
* Figure out the issues with IMGUI renderpass and re-enable the UI rendering
* Detect window minimization and handle accordingly in the renderer. 