### PR TITLE
Imgui renderpass

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -366,103 +366,103 @@ main() {
     });
 
     while (main_window.is_active()) {
-	float dt = (float)glfwGetTime();
+        float dt = (float)glfwGetTime();
 
-	if (do_reload ||
-	    glfwGetKey(main_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS &&
-	      glfwGetKey(main_window, GLFW_KEY_R) == GLFW_PRESS) {
-	    console_log_info("Reloading shaders...");
+        if (do_reload ||
+            glfwGetKey(main_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS &&
+              glfwGetKey(main_window, GLFW_KEY_R) == GLFW_PRESS) {
+            console_log_info("Reloading shaders...");
 
-	    test_shader.compile("shaders/shader.vert", "shaders/shader.frag");
-	    test_pipeline.reload_from_shader(
-	      test_shader, rp, test_descriptor_sets.get_layout());
+            test_shader.compile("shaders/shader.vert", "shaders/shader.frag");
+            test_pipeline.reload_from_shader(
+              test_shader, rp, test_descriptor_sets.get_layout());
 
-	    do_reload = false;
-	}
+            do_reload = false;
+        }
 
-	// if(glfwGetKey(main_window, GLFW_KEY_W) == GLFW_PRESS) { // forward
-	//     camera.m_velocity.z = -1;
+        // if(glfwGetKey(main_window, GLFW_KEY_W) == GLFW_PRESS) { // forward
+        //     camera.m_velocity.z = -1;
 
-	// }
-	// if(glfwGetKey(main_window, GLFW_KEY_A) == GLFW_PRESS) { // left
-	//     camera.m_velocity.x = 1;
-	// }
-	// if(glfwGetKey(main_window, GLFW_KEY_S) == GLFW_PRESS) { // back
-	//     camera.m_velocity.z = 1;
-	// }
-	// if(glfwGetKey(main_window, GLFW_KEY_D) == GLFW_PRESS) { // right
-	//     camera.m_velocity.x = 1;
-	// }
+        // }
+        // if(glfwGetKey(main_window, GLFW_KEY_A) == GLFW_PRESS) { // left
+        //     camera.m_velocity.x = 1;
+        // }
+        // if(glfwGetKey(main_window, GLFW_KEY_S) == GLFW_PRESS) { // back
+        //     camera.m_velocity.z = 1;
+        // }
+        // if(glfwGetKey(main_window, GLFW_KEY_D) == GLFW_PRESS) { // right
+        //     camera.m_velocity.x = 1;
+        // }
 
-	// camera.update();
+        // camera.update();
 
-	// acquire next image ( then record)
-	uint32_t frame = main_window_swapchain.read_acquired_frame();
-	vk::vk_command_buffer current =
-	  main_window_swapchain.get_active_command_buffer(frame);
+        // acquire next image ( then record)
+        uint32_t frame = main_window_swapchain.read_acquired_frame();
+        vk::vk_command_buffer current =
+          main_window_swapchain.get_active_command_buffer(frame);
 
-	//! @note Updating our uniforms before we draw
-	static auto startTime = std::chrono::high_resolution_clock::now();
+        //! @note Updating our uniforms before we draw
+        static auto startTime = std::chrono::high_resolution_clock::now();
 
-	auto currentTime = std::chrono::high_resolution_clock::now();
-	float time = std::chrono::duration<float, std::chrono::seconds::period>(
-		       currentTime - startTime)
-		       .count();
+        auto currentTime = std::chrono::high_resolution_clock::now();
+        float time = std::chrono::duration<float, std::chrono::seconds::period>(
+                   currentTime - startTime)
+                   .count();
 
-	camera_data_uniform ubo{};
-	ubo.Model = glm::translate(ubo.Model, glm::vec3(0.f, 0.f, 0.f));
-	ubo.Model = glm::rotate(glm::mat4(1.0f),
-				time * glm::radians(90.0f),
-				glm::vec3(0.0f, 0.0f, 1.0f));
-	ubo.View = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f),
-			       glm::vec3(0.0f, 0.0f, 0.0f),
-			       glm::vec3(0.0f, 0.0f, 1.0f));
-	ubo.Projection = glm::perspective(
-	  glm::radians(45.0f), width / (float)height, 0.1f, 10.0f);
-	ubo.Projection[1][1] *= -1;
+        camera_data_uniform ubo{};
+        ubo.Model = glm::translate(ubo.Model, glm::vec3(0.f, 0.f, 0.f));
+        ubo.Model = glm::rotate(glm::mat4(1.0f),
+                    time * glm::radians(90.0f),
+                    glm::vec3(0.0f, 0.0f, 1.0f));
+        ubo.View = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f),
+                       glm::vec3(0.0f, 0.0f, 0.0f),
+                       glm::vec3(0.0f, 0.0f, 1.0f));
+        ubo.Projection = glm::perspective(
+          glm::radians(45.0f), width / (float)height, 0.1f, 10.0f);
+        ubo.Projection[1][1] *= -1;
 
-	glm::mat4 MVP = ubo.Projection * ubo.View * ubo.Model;
-	test_uniforms[frame].update(&MVP, sizeof(MVP));
+        glm::mat4 MVP = ubo.Projection * ubo.View * ubo.Model;
+        test_uniforms[frame].update(&MVP, sizeof(MVP));
 
-	// Start recording
-	main_window_swapchain.begin(current);
-
-
-	test_pipeline.bind(current);
-	test_descriptor_sets.bind(current,
-				  main_window_swapchain.current_frame(),
-				  test_pipeline.get_layout());
-
-	// draw (after recording)
-	new_mesh.draw(current);
-
-	main_window_swapchain.end(current);
-        
-
-	//! @note This submits the command buffer and also presents the command
-	//! buffer as well
-	main_window_swapchain.submit(current);
-
-    test_imgui.begin();
-    ImGui::Begin("Viewport");
-    ImGui::Button("Texture Image 0");
-
-    ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
-    // ImGui::Image(test_descriptor_sets.get(frame), ImVec2{ 100, 100 });
-
-    // ImGui::Image()
-    float floaty;
-    if (ImGui::InputFloat("floaty", &floaty)) {
-        console_log_info("Floaty is: {}", floaty);
-    }
-    ImGui::End();
-    test_imgui.end(current, main_window_swapchain);
+        // Start recording
+        main_window_swapchain.begin(current);
 
 
-	// presenting frame (after drawing that frame)
-	main_window_swapchain.present();
+        test_pipeline.bind(current);
+        test_descriptor_sets.bind(current,
+                      main_window_swapchain.current_frame(),
+                      test_pipeline.get_layout());
 
-	glfwPollEvents();
+        // draw (after recording)
+        new_mesh.draw(current);
+
+        main_window_swapchain.end(current);
+            
+
+        //! @note This submits the command buffer and also presents the command
+        //! buffer as well
+        main_window_swapchain.submit(current);
+
+        test_imgui.begin();
+        ImGui::Begin("Viewport");
+        ImGui::Button("Texture Image 0");
+
+        ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
+        // ImGui::Image(test_descriptor_sets.get(frame), ImVec2{ 100, 100 });
+
+        // ImGui::Image()
+        float floaty;
+        if (ImGui::InputFloat("floaty", &floaty)) {
+            console_log_info("Floaty is: {}", floaty);
+        }
+        ImGui::End();
+        test_imgui.end(current, main_window_swapchain);
+
+
+        // presenting frame (after drawing that frame)
+        main_window_swapchain.present();
+
+        glfwPollEvents();
     }
 
     // Lets make sure we destroy these objects in the order they're created

--- a/Application.cpp
+++ b/Application.cpp
@@ -345,9 +345,10 @@ main() {
     VkRenderPass rp = main_window_swapchain.get_renderpass();
     test_imgui.initialize(initiating_vulkan,
 			  main_physical_device,
-			  rp,
+			  main_window,
 			  main_window_swapchain.image_size(),
-			  main_window_swapchain.data().SurfaceFormat);
+			  main_window_swapchain.data().SurfaceFormat,
+              main_window_swapchain);
 
     bool do_reload = false;
 
@@ -426,21 +427,6 @@ main() {
 	// Start recording
 	main_window_swapchain.begin(current);
 
-	test_imgui.begin();
-	ImGui::Begin("Viewport");
-	ImGui::Button("Texture Image 0");
-
-	ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
-	// ImGui::Image(test_descriptor_sets.get(frame), ImVec2{ 100, 100 });
-
-	// ImGui::Image()
-	float floaty;
-	if (ImGui::InputFloat("floaty", &floaty)) {
-	    console_log_info("Floaty is: {}", floaty);
-	}
-	ImGui::End();
-
-	test_imgui.end(current);
 
 	test_pipeline.bind(current);
 	test_descriptor_sets.bind(current,
@@ -451,10 +437,27 @@ main() {
 	new_mesh.draw(current);
 
 	main_window_swapchain.end(current);
+        
 
 	//! @note This submits the command buffer and also presents the command
 	//! buffer as well
 	main_window_swapchain.submit(current);
+
+    test_imgui.begin();
+    ImGui::Begin("Viewport");
+    ImGui::Button("Texture Image 0");
+
+    ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
+    // ImGui::Image(test_descriptor_sets.get(frame), ImVec2{ 100, 100 });
+
+    // ImGui::Image()
+    float floaty;
+    if (ImGui::InputFloat("floaty", &floaty)) {
+        console_log_info("Floaty is: {}", floaty);
+    }
+    ImGui::End();
+    test_imgui.end(current, main_window_swapchain);
+
 
 	// presenting frame (after drawing that frame)
 	main_window_swapchain.present();

--- a/Application.cpp
+++ b/Application.cpp
@@ -28,39 +28,50 @@
 /*
 
 	[NOTE For Setting Up Multiple Render Passes]
-		- These are the three main render passes I want to focus in try getting to work within the engine
-		- As soon resizable swapchains could work and we can support viewports a lot better
+		- These are the three main render passes I want to focus in try
+   getting to work within the engine
+		- As soon resizable swapchains could work and we can support
+   viewports a lot better
 
 	- Geometry Pass (First Renderpass)
-		- Data contains crucial for framebuffers are COlor, Normals, depth, and other material-like for geometry
-	
+		- Data contains crucial for framebuffers are COlor, Normals,
+   depth, and other material-like for geometry
+
 	Lighting Pass (Second RenderPass)
 		- Sample textuyres (normals, depth) used from Geometry Pass
-		- Performs lighting operations (using sampled data about light sources such as position, color, intensity, etc)
+		- Performs lighting operations (using sampled data about light
+   sources such as position, color, intensity, etc)
 		- Send these information to a render target (swapchain image)
 		[ Implementation High-level detail ]
-		 	- Steps to doing this is the following
-				1. Create and allocate anther vulkan image for each attachment
+			- Steps to doing this is the following
+				1. Create and allocate anther vulkan image for
+   each attachment
 				2. Then associate an image view with it
-				3. Then create a geometry render pass (VkRenderPass) that contains your geometry information (contained per vertex)
-				4. Then create framebuffer that uses that specified renderpass
-	
+				3. Then create a geometry render pass
+   (VkRenderPass) that contains your geometry information (contained per vertex)
+				4. Then create framebuffer that uses that
+   specified renderpass
+
 	Shadow Map
 		- Involves casting a shadow onto your specific render targets
-		- Contains information such as shadow casters, shadow biases information
+		- Contains information such as shadow casters, shadow biases
+   information
 
 		[ Implementation High-level detail ]
-		 	- Creates depth target with (VkImage and VkImageView)
+			- Creates depth target with (VkImage and VkImageView)
 			- Create VkRenderPass (shadow pass object)
 			- Create Shadow pass VkPipeline (graphics pipeline)
-				- Would enable depth testing, backface culling (if needed)
+				- Would enable depth testing, backface culling
+   (if needed)
 			- Shadow Pass framebuffer
 			- Per light perspective do the following:
 				- Begin shadow render pass, bind framebuffer
 				- Bind shadow graphics pipeline
 				- Bind viewport and scissor
-				- Bind vertex and index buffers of scene geometry
-				- Bind descriptors (containing to its respective data)
+				- Bind vertex and index buffers of scene
+   geometry
+				- Bind descriptors (containing to its respective
+   data)
 				- End shadow renderpass
 
 
@@ -68,57 +79,63 @@
 
 class interactive_camera {
 public:
-    interactive_camera(float p_aspect_ratio) : m_aspect_ratio(p_aspect_ratio) {
-    }
-
+    interactive_camera(float p_aspect_ratio)
+      : m_aspect_ratio(p_aspect_ratio) {}
 
     void update() {
-        glm::mat4 cameraRotation = get_rotation();
-        m_position += glm::vec3(cameraRotation * glm::vec4(m_velocity * 0.5f, 0.f));
+	glm::mat4 cameraRotation = get_rotation();
+	m_position +=
+	  glm::vec3(cameraRotation * glm::vec4(m_velocity * 0.5f, 0.f));
     }
 
-
     glm::mat4 get_rotation() {
-        glm::quat pitchRotation = glm::angleAxis(m_pitch, glm::vec3 { 1.f, 0.f, 0.f });
-        glm::quat yawRotation = glm::angleAxis(m_yaw, glm::vec3 { 0.f, -1.f, 0.f });
+	glm::quat pitchRotation =
+	  glm::angleAxis(m_pitch, glm::vec3{ 1.f, 0.f, 0.f });
+	glm::quat yawRotation =
+	  glm::angleAxis(m_yaw, glm::vec3{ 0.f, -1.f, 0.f });
 
-        return glm::toMat4(yawRotation) * glm::toMat4(pitchRotation);
+	return glm::toMat4(yawRotation) * glm::toMat4(pitchRotation);
     }
 
     glm::mat4 get_view() {
-        glm::mat4 cameraTranslation = glm::translate(glm::mat4(1.f), m_position);
-        glm::mat4 cameraRotation = get_rotation();
-        return glm::inverse(cameraTranslation * cameraRotation);
+	glm::mat4 cameraTranslation =
+	  glm::translate(glm::mat4(1.f), m_position);
+	glm::mat4 cameraRotation = get_rotation();
+	return glm::inverse(cameraTranslation * cameraRotation);
     }
 
     glm::mat4 get_projection() {
-        m_projection = glm::mat4(1.f);
-        m_projection = glm::perspective(glm::radians(70.f), m_aspect_ratio, 1000.f, 0.1f);
-        // invert the Y direction on projection matrix so that we are more similar
-        // to opengl and gltf axis
-        m_projection[1][1] *= -1;
-        return m_projection;
+	m_projection = glm::mat4(1.f);
+	m_projection =
+	  glm::perspective(glm::radians(70.f), m_aspect_ratio, 1000.f, 0.1f);
+	// invert the Y direction on projection matrix so that we are more
+	// similar to opengl and gltf axis
+	m_projection[1][1] *= -1;
+	return m_projection;
     }
 
 public:
-    glm::vec3 m_velocity = {0.f, 0.f, 0.f};
+    glm::vec3 m_velocity = { 0.f, 0.f, 0.f };
+
 private:
-    float m_aspect_ratio=0.f;
+    float m_aspect_ratio = 0.f;
     glm::mat4 m_view;
     glm::mat4 m_projection;
-    glm::vec3 m_position = {0.f, 0.f, 0.f};
+    glm::vec3 m_position = { 0.f, 0.f, 0.f };
     // vertical rotation
-    float m_pitch { 0.f };
+    float m_pitch{ 0.f };
     // horizontal rotation
-    float m_yaw { 0.f };
+    float m_yaw{ 0.f };
 };
 
-vk::vk_shader test_shader_compilation() {
-    vk::vk_shader test_compiled_shader = vk::vk_shader::from_source_files("shaders/shader.vert", "shaders/shader.frag");
+vk::vk_shader
+test_shader_compilation() {
+    vk::vk_shader test_compiled_shader = vk::vk_shader::from_source_files(
+      "shaders/shader.vert", "shaders/shader.frag");
 
     // setup vertex attributes or smth
     // set some uniforms as well
-    
+
     return test_compiled_shader;
 }
 
@@ -128,8 +145,8 @@ main() {
 
     //! @note Initializing GLFW
     if (!glfwInit()) {
-        fmt::println("glfwInit Initialized!!!");
-        return -1;
+	fmt::println("glfwInit Initialized!!!");
+	return -1;
     }
 
     //! @note Setup GLFW Window
@@ -159,22 +176,36 @@ main() {
     vk::vk_swapchain main_window_swapchain =
       vk::vk_swapchain(main_physical_device, main_driver, main_window);
     main_window_swapchain.set_background_color({ 0.f, 0.f, 0.f, 1.f });
-    
-    //vk::shader_watcher watcher("shaders");
-    vk::vk_shader test_shader = vk::vk_shader("shaders/shader.vert", "shaders/shader.frag");
-    // watcher.add_to_watchlist(test_shader, "shader.vert", "shader.frag");
-    
-	// vk::vk_shader test_shader = vk::vk_shader("shader_useful_directory/geometry/vert.spv","shader_useful_directory/geometry/frag.spv");
-    test_shader.set_vertex_attributes({
-		{.location = 0, .binding = 0, .format = VK_FORMAT_R32G32B32_SFLOAT, .offset = offsetof(vk::vertex, Position)},
-		{.location = 1, .binding = 0, .format = VK_FORMAT_R32G32B32A32_SFLOAT, .offset = offsetof(vk::vertex, Color)},
-        {.location = 2, .binding = 0, .format = VK_FORMAT_R32G32B32A32_SFLOAT, .offset = offsetof(vk::vertex, Normals)},
-		{.location = 3, .binding = 0, .format = VK_FORMAT_R32G32_SFLOAT, .offset = offsetof(vk::vertex, Uv)}
-    });
 
-	test_shader.set_vertex_bind_attributes({
-		{.binding = 0, .stride = sizeof(vk::vertex), .inputRate = VK_VERTEX_INPUT_RATE_VERTEX}
-	});
+    // vk::shader_watcher watcher("shaders");
+    vk::vk_shader test_shader =
+      vk::vk_shader("shaders/shader.vert", "shaders/shader.frag");
+    // watcher.add_to_watchlist(test_shader, "shader.vert", "shader.frag");
+
+    // vk::vk_shader test_shader =
+    // vk::vk_shader("shader_useful_directory/geometry/vert.spv","shader_useful_directory/geometry/frag.spv");
+    test_shader.set_vertex_attributes(
+      { { .location = 0,
+	  .binding = 0,
+	  .format = VK_FORMAT_R32G32B32_SFLOAT,
+	  .offset = offsetof(vk::vertex, Position) },
+	{ .location = 1,
+	  .binding = 0,
+	  .format = VK_FORMAT_R32G32B32A32_SFLOAT,
+	  .offset = offsetof(vk::vertex, Color) },
+	{ .location = 2,
+	  .binding = 0,
+	  .format = VK_FORMAT_R32G32B32A32_SFLOAT,
+	  .offset = offsetof(vk::vertex, Normals) },
+	{ .location = 3,
+	  .binding = 0,
+	  .format = VK_FORMAT_R32G32_SFLOAT,
+	  .offset = offsetof(vk::vertex, Uv) } });
+
+    test_shader.set_vertex_bind_attributes(
+      { { .binding = 0,
+	  .stride = sizeof(vk::vertex),
+	  .inputRate = VK_VERTEX_INPUT_RATE_VERTEX } });
 
     // adding descriptor sets
     // creating our vertex and index buffers
@@ -190,14 +221,14 @@ main() {
     test_uniforms.resize(main_window_swapchain.image_size());
 
     for (size_t i = 0; i < test_uniforms.size(); i++) {
-        test_uniforms[i] = vk::vk_uniform_buffer(size_of_bytes);
+	test_uniforms[i] = vk::vk_uniform_buffer(size_of_bytes);
     }
 
     /*
-        Refactor descriptor sets
+	Refactor descriptor sets
 
-        - Set a single descriptor sets as the size of the amount of images
-        - Then we have a single descriptor sets that we will create for scene
+	- Set a single descriptor sets as the size of the amount of images
+	- Then we have a single descriptor sets that we will create for scene
        objects (like textures, etc)
     */
 
@@ -206,30 +237,56 @@ main() {
     //! @note Now without needing to manually set the layout bindings manually,
     //! this will set up the descriptor sets automatically
     // this descriptor set layout is for shaders/shader.*
-    // - Used to specify what kinds of data will this descriptor set be containing
-	vk::vk_descriptor_set test_descriptor_sets = vk::vk_descriptor_set(image_count,
-	{
-		{.binding = 0, .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_VERTEX_BIT, .pImmutableSamplers  = nullptr},
-		{.binding = 1, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT, .pImmutableSamplers  = nullptr}
-	}
-	);
+    // - Used to specify what kinds of data will this descriptor set be
+    // containing
+    vk::vk_descriptor_set test_descriptor_sets = vk::vk_descriptor_set(
+      image_count,
+      { { .binding = 0,
+	  .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+	  .descriptorCount = 1,
+	  .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+	  .pImmutableSamplers = nullptr },
+	{ .binding = 1,
+	  .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+	  .descriptorCount = 1,
+	  .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+	  .pImmutableSamplers = nullptr } });
 
     // Vulkan Pipeline Specifications
     // specifically binding descriptions for the pipeline to use
     std::vector<vk::vertex_binding_description> binding_descriptions = {
-        { "Vertex", 0, sizeof(vk::vertex), VK_VERTEX_INPUT_RATE_VERTEX }
+	{ "Vertex", 0, sizeof(vk::vertex), VK_VERTEX_INPUT_RATE_VERTEX }
     };
 
     // Specify vertex attributes
     std::vector<vk::pipeline_vertex_attributes> vertex_attributes = {
-        { "inPosition", 0, 0, offsetof(vk::vertex, Position), VK_FORMAT_R32G32B32A32_SFLOAT },
-        { "inColor", 0, 1, offsetof(vk::vertex, Color), VK_FORMAT_R32G32B32A32_SFLOAT },
-        { "inNormals", 0, 2, offsetof(vk::vertex, Normals), VK_FORMAT_R32G32B32A32_SFLOAT },
-        { "inTexCoords", 0, 3, offsetof(vk::vertex, Uv), VK_FORMAT_R32G32B32A32_SFLOAT }
+	{ "inPosition",
+	  0,
+	  0,
+	  offsetof(vk::vertex, Position),
+	  VK_FORMAT_R32G32B32A32_SFLOAT },
+	{ "inColor",
+	  0,
+	  1,
+	  offsetof(vk::vertex, Color),
+	  VK_FORMAT_R32G32B32A32_SFLOAT },
+	{ "inNormals",
+	  0,
+	  2,
+	  offsetof(vk::vertex, Normals),
+	  VK_FORMAT_R32G32B32A32_SFLOAT },
+	{ "inTexCoords",
+	  0,
+	  3,
+	  offsetof(vk::vertex, Uv),
+	  VK_FORMAT_R32G32B32A32_SFLOAT }
     };
 
     // setting up vulkan pipeline
-    vk::vk_pipeline test_pipeline = vk::vk_pipeline(main_window_swapchain.get_renderpass(),test_shader, test_descriptor_sets.get_layout());
+    vk::vk_pipeline test_pipeline =
+      vk::vk_pipeline(main_window_swapchain.get_renderpass(),
+		      test_shader,
+		      test_descriptor_sets.get_layout());
 
     // Loading and using textures
     // vk::vk_texture test_texture("models/viking_room.png");
@@ -238,19 +295,19 @@ main() {
 
     // updating descriptor sets
     /*
-        API For writing uniforms to the shader
-            - mesh contains index and vertex buffers
-            - test_uniforms passes all of our camera data
-            - passing in our texture
-        update_descriptor_sets(mesh, test_uniforms)
+	API For writing uniforms to the shader
+	    - mesh contains index and vertex buffers
+	    - test_uniforms passes all of our camera data
+	    - passing in our texture
+	update_descriptor_sets(mesh, test_uniforms)
 
-        This call should be updated to doing this:
+	This call should be updated to doing this:
 
-        Using vk_descriptor_set used as a single descriptor set rather then
+	Using vk_descriptor_set used as a single descriptor set rather then
        supporting multiple. That is something that the vk_descriptor_set_manager
        should do
 
-        descriptor_set[i].update_descriptor_set(uniform_buffer[i]);
+	descriptor_set[i].update_descriptor_set(uniform_buffer[i]);
     */
 
     // test_descriptor_sets.update_uniforms(test_uniforms);
@@ -258,128 +315,151 @@ main() {
     // test_descriptor_sets.update_vertex(test_vertex_buffer);
     vk::vk_texture my_texture = new_mesh.get_texture(0);
 
-    test_descriptor_sets.update_test_descriptors(test_uniforms, test_vertex_buffer, my_texture);
-	// test_descriptor_sets.update_test_descriptors(test_uniforms, test_vertex_buffer, new_mesh.get_textures());
+    test_descriptor_sets.update_test_descriptors(
+      test_uniforms, test_vertex_buffer, my_texture);
+    // test_descriptor_sets.update_test_descriptors(test_uniforms,
+    // test_vertex_buffer, new_mesh.get_textures());
 
     /*
 
-	// Essentially there are going to be vk_descriptor_set that is to be defined as a single descriptor set
+	// Essentially there are going to be vk_descriptor_set that is to be
+    defined as a single descriptor set
 	// Then set the descriptor set as probably a shader source group
     vk::vk_descriptor_set_manager desc_manager(image_size); // img_size = 3
     std::vector<vk::vk_descriptor_set> descriptor_sets(3);
 
       for(size_t i = 0; i < image_size; i++) {
-        // desc_manager.write(i, uniform);
-        descriptor_sets[i].write_uniform(uniform);
-        descriptor_sets[i].write_texture(&test_texture);
+	// desc_manager.write(i, uniform);
+	descriptor_sets[i].write_uniform(uniform);
+	descriptor_sets[i].write_texture(&test_texture);
 
       }
 
     */
-	glm::vec3 Position = {0.f, 0.f, 0.f};
+    glm::vec3 Position = { 0.f, 0.f, 0.f };
 
-
-	// perspective_camera camera = perspective_camera((float)width / height);
+    // perspective_camera camera = perspective_camera((float)width / height);
     // interactive_camera camera = interactive_camera(((width) / height));
 
     vk::vk_imgui test_imgui = vk::vk_imgui();
     VkRenderPass rp = main_window_swapchain.get_renderpass();
-    test_imgui.initialize(initiating_vulkan, main_physical_device, rp, main_window_swapchain.image_size(), main_window_swapchain.data().SurfaceFormat);
+    test_imgui.initialize(initiating_vulkan,
+			  main_physical_device,
+			  rp,
+			  main_window_swapchain.image_size(),
+			  main_window_swapchain.data().SurfaceFormat);
 
     bool do_reload = false;
 
     auto watcher = wtr::watch("./shaders", [&](wtr::event ev) mutable {
-        if (ev.effect_type == wtr::event::effect_type::modify && ev.path_type == wtr::event::path_type::file) {
+	if (ev.effect_type == wtr::event::effect_type::modify &&
+	    ev.path_type == wtr::event::path_type::file) {
 
-            if (ev.path_name.filename().string() == "shader.vert" || ev.path_name.filename().string() == "shader.frag") {
-                console_log_info("Detected shader reload stuff!!!!!!!!!!!!!!1l");
-                do_reload = true;
-            }
-        }
+	    if (ev.path_name.filename().string() == "shader.vert" ||
+		ev.path_name.filename().string() == "shader.frag") {
+		console_log_info(
+		  "Detected shader reload stuff!!!!!!!!!!!!!!1l");
+		do_reload = true;
+	    }
+	}
     });
 
     while (main_window.is_active()) {
-        float dt = (float)glfwGetTime();
-        
-        if (do_reload || glfwGetKey(main_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS &&
-            glfwGetKey(main_window, GLFW_KEY_R) == GLFW_PRESS) {
-            console_log_info("Reloading shaders...");
+	float dt = (float)glfwGetTime();
 
-            test_shader.compile("shaders/shader.vert", "shaders/shader.frag");
-            test_pipeline.reload_from_shader(test_shader, rp, test_descriptor_sets.get_layout());
+	if (do_reload ||
+	    glfwGetKey(main_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS &&
+	      glfwGetKey(main_window, GLFW_KEY_R) == GLFW_PRESS) {
+	    console_log_info("Reloading shaders...");
 
-            do_reload = false;
-            
-        }
+	    test_shader.compile("shaders/shader.vert", "shaders/shader.frag");
+	    test_pipeline.reload_from_shader(
+	      test_shader, rp, test_descriptor_sets.get_layout());
 
-        // if(glfwGetKey(main_window, GLFW_KEY_W) == GLFW_PRESS) { // forward
-        //     camera.m_velocity.z = -1;
+	    do_reload = false;
+	}
 
-        // }
-        // if(glfwGetKey(main_window, GLFW_KEY_A) == GLFW_PRESS) { // left
-        //     camera.m_velocity.x = 1;
-        // }
-        // if(glfwGetKey(main_window, GLFW_KEY_S) == GLFW_PRESS) { // back
-        //     camera.m_velocity.z = 1;
-        // }
-        // if(glfwGetKey(main_window, GLFW_KEY_D) == GLFW_PRESS) { // right
-        //     camera.m_velocity.x = 1;
-        // }
+	// if(glfwGetKey(main_window, GLFW_KEY_W) == GLFW_PRESS) { // forward
+	//     camera.m_velocity.z = -1;
 
-        // camera.update();
+	// }
+	// if(glfwGetKey(main_window, GLFW_KEY_A) == GLFW_PRESS) { // left
+	//     camera.m_velocity.x = 1;
+	// }
+	// if(glfwGetKey(main_window, GLFW_KEY_S) == GLFW_PRESS) { // back
+	//     camera.m_velocity.z = 1;
+	// }
+	// if(glfwGetKey(main_window, GLFW_KEY_D) == GLFW_PRESS) { // right
+	//     camera.m_velocity.x = 1;
+	// }
 
-        // acquire next image ( then record)
-        uint32_t frame = main_window_swapchain.read_acquired_frame();
-        vk::vk_command_buffer current = main_window_swapchain.get_active_command_buffer(frame);
+	// camera.update();
 
-        //! @note Updating our uniforms before we draw
-        static auto startTime = std::chrono::high_resolution_clock::now();
+	// acquire next image ( then record)
+	uint32_t frame = main_window_swapchain.read_acquired_frame();
+	vk::vk_command_buffer current =
+	  main_window_swapchain.get_active_command_buffer(frame);
 
-        auto currentTime = std::chrono::high_resolution_clock::now();
-        float time = std::chrono::duration<float, std::chrono::seconds::period>(currentTime - startTime).count();
+	//! @note Updating our uniforms before we draw
+	static auto startTime = std::chrono::high_resolution_clock::now();
 
-        camera_data_uniform ubo{};
-        ubo.Model = glm::translate(ubo.Model, glm::vec3(0.f, 0.f, 0.f));
-        ubo.Model = glm::rotate(glm::mat4(1.0f), time * glm::radians(90.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-        ubo.View = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
-        ubo.Projection = glm::perspective(glm::radians(45.0f), width / (float) height, 0.1f, 10.0f);
-        ubo.Projection[1][1] *= -1;
+	auto currentTime = std::chrono::high_resolution_clock::now();
+	float time = std::chrono::duration<float, std::chrono::seconds::period>(
+		       currentTime - startTime)
+		       .count();
 
-        glm::mat4 MVP = ubo.Projection * ubo.View * ubo.Model;
-        test_uniforms[frame].update(&MVP, sizeof(MVP));
+	camera_data_uniform ubo{};
+	ubo.Model = glm::translate(ubo.Model, glm::vec3(0.f, 0.f, 0.f));
+	ubo.Model = glm::rotate(glm::mat4(1.0f),
+				time * glm::radians(90.0f),
+				glm::vec3(0.0f, 0.0f, 1.0f));
+	ubo.View = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f),
+			       glm::vec3(0.0f, 0.0f, 0.0f),
+			       glm::vec3(0.0f, 0.0f, 1.0f));
+	ubo.Projection = glm::perspective(
+	  glm::radians(45.0f), width / (float)height, 0.1f, 10.0f);
+	ubo.Projection[1][1] *= -1;
 
+	glm::mat4 MVP = ubo.Projection * ubo.View * ubo.Model;
+	test_uniforms[frame].update(&MVP, sizeof(MVP));
 
-        // Start recording
-        main_window_swapchain.begin(current);
-        //test_imgui.begin();
+	// Start recording
+	main_window_swapchain.begin(current);
 
+	test_imgui.begin();
+	ImGui::Begin("Viewport");
+	ImGui::Button("Texture Image 0");
 
-        test_pipeline.bind(current);
-        test_descriptor_sets.bind(current,main_window_swapchain.current_frame(), test_pipeline.get_layout());
+	ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
+	// ImGui::Image(test_descriptor_sets.get(frame), ImVec2{ 100, 100 });
 
-        // draw (after recording)
-        new_mesh.draw(current);
+	// ImGui::Image()
+	float floaty;
+	if (ImGui::InputFloat("floaty", &floaty)) {
+	    console_log_info("Floaty is: {}", floaty);
+	}
+	ImGui::End();
 
-        //ImGui::Begin("Viewport");
-        //ImGui::Button("Texture Image 0");
+	test_imgui.end(current);
 
-        // ImVec2 viewport_panel_size = ImGui::GetContentRegionAvail();
-        // ImGui::Image(test_descriptor_sets.get(frame), ImVec2{100, 100});
+	test_pipeline.bind(current);
+	test_descriptor_sets.bind(current,
+				  main_window_swapchain.current_frame(),
+				  test_pipeline.get_layout());
 
-        // ImGui::Image()
-        //ImGui::End();
+	// draw (after recording)
+	new_mesh.draw(current);
 
-        //test_imgui.end(current);
-        main_window_swapchain.end(current);
+	main_window_swapchain.end(current);
 
-        //! @note This submits the command buffer and also presents the command buffer as well
-        main_window_swapchain.submit(current);
+	//! @note This submits the command buffer and also presents the command
+	//! buffer as well
+	main_window_swapchain.submit(current);
 
+	// presenting frame (after drawing that frame)
+	main_window_swapchain.present();
 
-        // presenting frame (after drawing that frame)
-        main_window_swapchain.present();
-
-        glfwPollEvents();
+	glfwPollEvents();
     }
 
     // Lets make sure we destroy these objects in the order they're created
@@ -390,13 +470,15 @@ main() {
     // just before they get destroyed!!
     vkDeviceWaitIdle(main_driver);
 
-    //! @note This would probably be something specified in something like vk_context::submit_resource_free([](){ m_command_buffers.destroy(); })
-    //! @note Whenever something needs to be submitted and destroyed when the application shuts down
+    //! @note This would probably be something specified in something like
+    //! vk_context::submit_resource_free([](){ m_command_buffers.destroy(); })
+    //! @note Whenever something needs to be submitted and destroyed when the
+    //! application shuts down
     test_imgui.destroy();
 
     my_texture.destroy();
     for (size_t i = 0; i < test_uniforms.size(); i++) {
-        test_uniforms[i].destroy();
+	test_uniforms[i].destroy();
     }
 
     test_descriptor_sets.destroy();

--- a/imgui.ini
+++ b/imgui.ini
@@ -10,8 +10,8 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-Pos=195,203
-Size=274,209
+Pos=546,243
+Size=274,252
 Collapsed=0
 
 [Window][Testing]

--- a/imgui.ini
+++ b/imgui.ini
@@ -10,9 +10,9 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-ViewportPos=2280,422
+ViewportPos=1065,275
 ViewportId=0x995B0CF8
-Size=367,498
+Size=367,976
 Collapsed=0
 
 [Window][Testing]

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,5 +1,5 @@
 [Window][Debug##Default]
-Pos=60,60
+Pos=60,279
 Size=400,400
 Collapsed=0
 
@@ -10,8 +10,7 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-ViewportPos=7,488
-ViewportId=0x995B0CF8
+Pos=105,314
 Size=274,178
 Collapsed=0
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -10,8 +10,9 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-Pos=546,243
-Size=274,252
+ViewportPos=7,488
+ViewportId=0x995B0CF8
+Size=274,178
 Collapsed=0
 
 [Window][Testing]

--- a/imgui.ini
+++ b/imgui.ini
@@ -10,9 +10,8 @@ Size=550,680
 Collapsed=0
 
 [Window][Viewport]
-ViewportPos=1065,275
-ViewportId=0x995B0CF8
-Size=367,976
+Pos=195,203
+Size=274,209
 Collapsed=0
 
 [Window][Testing]

--- a/src/vulkan-cpp/vk_command_buffer.cpp
+++ b/src/vulkan-cpp/vk_command_buffer.cpp
@@ -2,6 +2,7 @@
 #include <vulkan-cpp/helper_functions.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan/vulkan_core.h>
 
 namespace vk {
 
@@ -48,6 +49,18 @@ namespace vk {
                                           &m_command_buffer_handler),
                  "vkAllocateCommandBuffers",
                  __FUNCTION__);
+
+        VkSemaphoreCreateInfo semaphore_create_info = {
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+        };
+
+
+        vk_check(vkCreateSemaphore(m_driver, 
+                                   &semaphore_create_info,
+                                   nullptr,
+                                   &m_finished_semaphore), 
+                 "vkCreateSemaphore",
+                 __FUNCTION__);
     }
 
     void vk_command_buffer::begin(const VkCommandBufferUsageFlags& p_usage) {
@@ -72,6 +85,7 @@ namespace vk {
     }
 
     void vk_command_buffer::destroy() {
+        vkDestroySemaphore(m_driver, m_finished_semaphore, nullptr);
         vkFreeCommandBuffers(
           m_driver, m_command_pool, 1, &m_command_buffer_handler);
         vkDestroyCommandPool(m_driver, m_command_pool, nullptr);

--- a/src/vulkan-cpp/vk_imgui.cpp
+++ b/src/vulkan-cpp/vk_imgui.cpp
@@ -8,6 +8,7 @@
 #include <vulkan-cpp/vk_context.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
 #include <vulkan-cpp/logger.hpp>
+#include <vulkan/vulkan_core.h>
 
 namespace vk {
     static void imgui_color_layout_customization() {
@@ -105,9 +106,10 @@ namespace vk {
 
     void vk_imgui::initialize(const VkInstance& p_instance,
 			      const VkPhysicalDevice& p_physical,
-			      const VkRenderPass& p_rp,
+			      const VkSurfaceKHR& p_surface,
 			      uint32_t p_image_size,
-			      const VkSurfaceFormatKHR& p_surface_format) {
+			      const VkSurfaceFormatKHR& p_surface_format,
+                  const vk_swapchain& p_swapchain) {
         console_log_info("Imgui Debug Track #0");
         //! @note Setting up imgui stuff.
         // Setup Dear ImGui context
@@ -146,9 +148,11 @@ namespace vk {
         attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
+
         VkAttachmentReference color_attachment = {};
         color_attachment.attachment = 0;
         color_attachment.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
 
         VkSubpassDescription subpass = {};
         subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -186,9 +190,9 @@ namespace vk {
         };
 
         m_imgui_renderpass = vk_renderpass({
-            .attachments = std::span(attachments),
-            .subpass_descriptions = std::span(subpasses),
-            .dependencies = std::span(dependencies),
+            .attachments = attachments,
+            .subpass_descriptions = subpasses,
+            .dependencies = dependencies,
         });
 
 
@@ -234,6 +238,26 @@ namespace vk {
         console_log_warn("After ImGui_ImplGlfw_InitForVulkan called!");
 
         ImGui_ImplVulkan_CreateFontsTexture();
+
+        // create imgui viewport (i.e framebuffers)
+        uint32_t image_count = p_swapchain.image_size();
+        m_viewport_framebuffers.resize(image_count);
+
+        p_swapchain.create_new_framebuffers(m_imgui_renderpass, m_viewport_framebuffers, attachment_color);
+        
+        // Create a separate command buffer for ImGUI to avoid clashing with 
+        // incompatible pipelines and such
+        
+        uint32_t present_family_index = m_driver.get_physical_driver_context()
+            .get_presentation_index(p_surface);
+        
+        console_log_info("(IMGUI): Chosen family index: {}", present_family_index);
+        command_buffer_properties cmd_buf_props(
+            present_family_index,
+            Primary,
+            VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
+        );
+        m_command_buffer = vk_command_buffer(cmd_buf_props);
     }
 
     void vk_imgui::begin() {
@@ -242,7 +266,7 @@ namespace vk {
         ImGui::NewFrame();
     }
 
-    void vk_imgui::end(const VkCommandBuffer& p_current) {
+    void vk_imgui::end(const VkCommandBuffer& p_current, vk_swapchain& p_swapchain) {
         ImGui::Render();
 
         // auto current_cmd_buffer = get_current_command_buffer();
@@ -258,10 +282,37 @@ namespace vk {
         //     current,
         //   width,
         //   height); // Pass window width and height for initial viewport setup
+    
+        m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+        
+        VkClearValue clear_color = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
+        VkRenderPassBeginInfo begin_renderpass_info = {
+            .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+            .renderPass = m_imgui_renderpass,
+            .framebuffer = m_viewport_framebuffers.at(p_swapchain.current_frame()),
+            .renderArea = {
+                .offset = {0, 0},
+                .extent = p_swapchain.get_extent()
+            },
+            .clearValueCount = 1,
+            .pClearValues = &clear_color,
+        };
+
+        vkCmdBeginRenderPass(m_command_buffer,
+            &begin_renderpass_info,
+            VK_SUBPASS_CONTENTS_INLINE
+        );
 
         //! @note This works, dont modify.
         ImDrawData* draw_data = ImGui::GetDrawData();
-        ImGui_ImplVulkan_RenderDrawData(draw_data, p_current);
+        ImGui_ImplVulkan_RenderDrawData(draw_data, m_command_buffer);
+        
+        vkCmdEndRenderPass(m_command_buffer);
+
+        m_command_buffer.end();
+        
+        p_swapchain.submit(m_command_buffer);
+
 
         ImGuiIO& io = ImGui::GetIO();
         (void)io;
@@ -270,6 +321,7 @@ namespace vk {
             ImGui::UpdatePlatformWindows();
             ImGui::RenderPlatformWindowsDefault();
         }
+
     }
 
     void vk_imgui::destroy() {
@@ -277,7 +329,18 @@ namespace vk {
         //! destructed when the application shutsdown
         ImGui_ImplVulkan_Shutdown();
         vkDestroyDescriptorPool(m_driver, m_imgui_desc_pool, nullptr);
-        vkDestroyRenderPass(m_driver, m_imgui_renderpass, nullptr);
+        // vkDestroyRenderPass(m_driver, m_imgui_renderpass, nullptr);
+        m_imgui_renderpass.destroy();
+
+        //NOTE: Not sure if we still need the separate command pool given the exclusive command buffer
+        // and the fact that vk_command_buffer appears to encapsulate its own command pool
         vkDestroyCommandPool(m_driver, m_imgui_command_pool, nullptr);
+
+        m_command_buffer.destroy();
+
+        // destroy all the framebuffers n stuff
+        for (auto & framebuffer : m_viewport_framebuffers) {
+            vkDestroyFramebuffer(m_driver, framebuffer, nullptr);
+        }
     }
 };

--- a/src/vulkan-cpp/vk_imgui.cpp
+++ b/src/vulkan-cpp/vk_imgui.cpp
@@ -145,7 +145,7 @@ namespace vk {
         attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
         attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
 
@@ -244,7 +244,7 @@ namespace vk {
         m_viewport_framebuffers.resize(image_count);
 
         p_swapchain.create_new_framebuffers(m_imgui_renderpass, m_viewport_framebuffers, attachment_color);
-        
+        p_swapchain.set_resize_callback(on_resize);
         // Create a separate command buffer for ImGUI to avoid clashing with 
         // incompatible pipelines and such
         

--- a/src/vulkan-cpp/vk_imgui.cpp
+++ b/src/vulkan-cpp/vk_imgui.cpp
@@ -43,32 +43,30 @@ namespace vk {
         colors[ImGuiCol_TitleBgActive] = ImVec4{ 0.15f, 0.1505f, 0.15f, 1.0f };
         colors[ImGuiCol_TitleBgCollapsed] =
           ImVec4{ 0.1f, 0.150f, 0.951f, 1.0f };
-    }
+        }
 
+        VkCommandPool imgui_create_command_pool() {
+        vk_driver driver = vk_driver::driver_context();
+        VkCommandPool pool = nullptr;
 
-    VkCommandPool imgui_create_command_pool() {
-		vk_driver driver = vk_driver::driver_context();
-		VkCommandPool pool = nullptr;
+        VkCommandPoolCreateInfo pool_ci = {
+            .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+            .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+            .queueFamilyIndex =
+              vk_physical_driver::physical_driver().get_queue_indices().Graphics
+        };
 
-		VkCommandPoolCreateInfo pool_ci = {
-			.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-			.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-			.queueFamilyIndex = vk_physical_driver::physical_driver().get_queue_indices().Graphics
-		};
+        vk_check(vkCreateCommandPool(driver, &pool_ci, nullptr, &pool),
+             "vkCreateCommandPool",
+             __FUNCTION__);
 
-		vk_check(vkCreateCommandPool(driver, &pool_ci, nullptr, &pool), "vkCreateCommandPool", __FUNCTION__);
-
-		return pool;
+        return pool;
     }
 
     vk_imgui::vk_imgui() {
         m_driver = vk_driver::driver_context();
 
-		m_imgui_command_pool = imgui_create_command_pool();
-
-
-
-
+        m_imgui_command_pool = imgui_create_command_pool();
 
         VkDescriptorPoolSize pool_sizes[] = {
             { VK_DESCRIPTOR_TYPE_SAMPLER, 100 },
@@ -100,15 +98,16 @@ namespace vk {
             m_driver, &desc_pool_create_info, nullptr, &m_imgui_desc_pool),
           "vkCreateDescriptorPool",
           __FUNCTION__);
-        console_log_info("After creating descriptor sets for IMGUI");
+            console_log_info("After creating descriptor sets for IMGUI");
     }
 
-	void vk_imgui::create_imgui_renderpass() {
-
-	}
+    void vk_imgui::create_imgui_renderpass() {}
 
     void vk_imgui::initialize(const VkInstance& p_instance,
-                              const VkPhysicalDevice& p_physical, const VkRenderPass& p_rp, uint32_t p_image_size, const VkSurfaceFormatKHR& p_surface_format) {
+			      const VkPhysicalDevice& p_physical,
+			      const VkRenderPass& p_rp,
+			      uint32_t p_image_size,
+			      const VkSurfaceFormatKHR& p_surface_format) {
         console_log_info("Imgui Debug Track #0");
         //! @note Setting up imgui stuff.
         // Setup Dear ImGui context
@@ -123,7 +122,7 @@ namespace vk {
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // Enable Docking
         io.ConfigFlags |=
           ImGuiConfigFlags_ViewportsEnable; // Enable Multi-Viewport / Platform
-                                            // Windows
+                            // Windows
         console_log_info("Imgui Debug Track #1");
 
         // Setting custom dark themed imgui layout
@@ -137,44 +136,66 @@ namespace vk {
             style.Colors[ImGuiCol_WindowBg].w = 1.0f;
         }
 
-		VkAttachmentDescription attachment = {};
-		attachment.format = p_surface_format.format;
-		attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-		attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-		attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-		attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        VkAttachmentDescription attachment = {};
+        attachment.format = p_surface_format.format;
+        attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-		VkAttachmentReference color_attachment = {};
-		color_attachment.attachment = 0;
-		color_attachment.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        VkAttachmentReference color_attachment = {};
+        color_attachment.attachment = 0;
+        color_attachment.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-		VkSubpassDescription subpass = {};
-		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-		subpass.colorAttachmentCount = 1;
-		subpass.pColorAttachments = &color_attachment;
+        VkSubpassDescription subpass = {};
+        subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass.colorAttachmentCount = 1;
+        subpass.pColorAttachments = &color_attachment;
 
-		VkSubpassDependency dependency = {};
-		dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-		dependency.dstSubpass = 0;
-		dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependency.srcAccessMask = 0; // or VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        VkSubpassDependency dependency = {};
+        dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        dependency.dstSubpass = 0;
+        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.srcAccessMask =
+          0; // or VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
-		VkRenderPassCreateInfo info = {};
-		info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-		info.attachmentCount = 1;
-		info.pAttachments = &attachment;
-		info.subpassCount = 1;
-		info.pSubpasses = &subpass;
-		info.dependencyCount = 1;
-		info.pDependencies = &dependency;
+        VkRenderPassCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+        info.attachmentCount = 1;
+        info.pAttachments = &attachment;
+        info.subpassCount = 1;
+        info.pSubpasses = &subpass;
+        info.dependencyCount = 1;
+        info.pDependencies = &dependency;
+
+        std::array attachments = {
+            attachment,
+        };
+
+        std::array subpasses = {
+            subpass,
+        };
+
+        std::array dependencies = {
+            dependency,
+        };
+
+        m_imgui_renderpass = vk_renderpass({
+            .attachments = std::span(attachments),
+            .subpass_descriptions = std::span(subpasses),
+            .dependencies = std::span(dependencies),
+        });
 
 
-		vk_check(vkCreateRenderPass(m_driver, &info, nullptr, &m_imgui_renderpass), "vkCreateRenderPass", __FUNCTION__);
+        // vk_check(
+        //   vkCreateRenderPass(m_driver, &info, nullptr, &m_imgui_renderpass),
+        //   "vkCreateRenderPass",
+        //   __FUNCTION__);
 
         console_log_info("Imgui Debug Track #3");
 
@@ -231,8 +252,8 @@ namespace vk {
 
         int width, height;
         glfwGetFramebufferSize(vk_window::native_window(),
-                               &width,
-                               &height); // Or use glfwget_windowSize
+                       &width,
+                       &height); // Or use glfwget_windowSize
         // updateViewport(
         //     current,
         //   width,
@@ -252,10 +273,11 @@ namespace vk {
     }
 
     void vk_imgui::destroy() {
-		//! @note This will probably be submitted at construction to be destructed when the application shutsdown
-		ImGui_ImplVulkan_Shutdown();
-		vkDestroyDescriptorPool(m_driver, m_imgui_desc_pool, nullptr);
-		vkDestroyRenderPass(m_driver, m_imgui_renderpass, nullptr);
-		vkDestroyCommandPool(m_driver, m_imgui_command_pool, nullptr);
+        //! @note This will probably be submitted at construction to be
+        //! destructed when the application shutsdown
+        ImGui_ImplVulkan_Shutdown();
+        vkDestroyDescriptorPool(m_driver, m_imgui_desc_pool, nullptr);
+        vkDestroyRenderPass(m_driver, m_imgui_renderpass, nullptr);
+        vkDestroyCommandPool(m_driver, m_imgui_command_pool, nullptr);
     }
 };

--- a/src/vulkan-cpp/vk_imgui.cpp
+++ b/src/vulkan-cpp/vk_imgui.cpp
@@ -109,7 +109,7 @@ namespace vk {
 			      const VkSurfaceKHR& p_surface,
 			      uint32_t p_image_size,
 			      const VkSurfaceFormatKHR& p_surface_format,
-                  const vk_swapchain& p_swapchain) {
+                  vk_swapchain& p_swapchain) {
         console_log_info("Imgui Debug Track #0");
         //! @note Setting up imgui stuff.
         // Setup Dear ImGui context
@@ -244,7 +244,12 @@ namespace vk {
         m_viewport_framebuffers.resize(image_count);
 
         p_swapchain.create_new_framebuffers(m_imgui_renderpass, m_viewport_framebuffers, attachment_color);
-        p_swapchain.set_resize_callback(on_resize);
+        
+        // there's likely a slightly more elegant way to express this
+        p_swapchain.register_resize_callback([this](const vk_swapchain& p_chain) {
+            this->on_resize(p_chain);
+        });
+
         // Create a separate command buffer for ImGUI to avoid clashing with 
         // incompatible pipelines and such
         
@@ -264,6 +269,14 @@ namespace vk {
         ImGui_ImplVulkan_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
+    }
+
+    void vk_imgui::on_resize(const vk_swapchain& p_swapchain) {
+        for (auto fb : m_viewport_framebuffers) {
+            vkDestroyFramebuffer(m_driver, fb, nullptr);
+        }
+
+        p_swapchain.create_new_framebuffers(m_imgui_renderpass, m_viewport_framebuffers, attachment_color); 
     }
 
     void vk_imgui::end(const VkCommandBuffer& p_current, vk_swapchain& p_swapchain) {

--- a/src/vulkan-cpp/vk_queue.cpp
+++ b/src/vulkan-cpp/vk_queue.cpp
@@ -37,6 +37,8 @@ namespace vk {
           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         // console_log_error("Debug #0 -- Tracked Here");
         VkSubmitInfo submit_info = {};
+        
+
         if (submission_t == submission_type::Async) {
             // console_log_warn("Submission Type == Async!!!");
             submit_info = { .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,

--- a/src/vulkan-cpp/vk_queue.cpp
+++ b/src/vulkan-cpp/vk_queue.cpp
@@ -31,26 +31,31 @@ namespace vk {
         m_present_completed_semaphore = create_semaphore(p_driver);
     }
 
-    void vk_queue::submit_to(const VkCommandBuffer& p_command_buffer,
+    void vk_queue::submit_to(const vk_command_buffer& p_command_buffer,
                              submission_type submission_t) {
 		VkPipelineStageFlags wait_flags =
           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         // console_log_error("Debug #0 -- Tracked Here");
         VkSubmitInfo submit_info = {};
+
+        auto cmd_buffer_handle = p_command_buffer.handle();
+
+        uint32_t wait_semaphore_count = m_wait_semaphore != VK_NULL_HANDLE ? 1 : 0;
+        m_signal_semaphore = p_command_buffer.get_finished_semaphore();
         
 
         if (submission_t == submission_type::Async) {
             // console_log_warn("Submission Type == Async!!!");
             submit_info = { .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
                             .pNext = nullptr,
-                            .waitSemaphoreCount = 1,
-                            .pWaitSemaphores = &m_present_completed_semaphore,
+                            .waitSemaphoreCount = wait_semaphore_count,
+                            .pWaitSemaphores = &m_wait_semaphore,
                             .pWaitDstStageMask = &wait_flags,
                             .commandBufferCount = 1,
-                            .pCommandBuffers = &p_command_buffer,
+                            .pCommandBuffers = &cmd_buffer_handle,
                             .signalSemaphoreCount = 1,
                             .pSignalSemaphores =
-                              &m_render_completed_semaphore };
+                              &m_signal_semaphore };
             // console_log_error("Debug #2 -- Tracked Here If Statement Async");
         }
         else {
@@ -60,22 +65,27 @@ namespace vk {
                             .pWaitSemaphores = nullptr,
                             .pWaitDstStageMask = nullptr,
                             .commandBufferCount = 1,
-                            .pCommandBuffers = &p_command_buffer,
+                            .pCommandBuffers = &cmd_buffer_handle,
                             .signalSemaphoreCount = 0,
                             .pSignalSemaphores = nullptr };
         }
 
         VkResult res = vkQueueSubmit(m_queue, 1, &submit_info, nullptr);
         vk_check(res, "vkQueueSubmit", __FUNCTION__);
+
+        m_wait_semaphore = m_signal_semaphore;
     }
 
     void vk_queue::present(uint32_t p_frame_index) {
+
+        uint32_t wait_semaphore_count = m_wait_semaphore != VK_NULL_HANDLE ? 1 : 0;
+
         VkPresentInfoKHR present_info = { .sType =
                                             VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
                                           .pNext = nullptr,
-                                          .waitSemaphoreCount = 1,
+                                          .waitSemaphoreCount = wait_semaphore_count,
                                           .pWaitSemaphores =
-                                            &m_render_completed_semaphore,
+                                            &m_wait_semaphore,
                                           .swapchainCount = 1,
                                           .pSwapchains = &m_swapchain_handler,
                                           .pImageIndices = &p_frame_index };
@@ -84,6 +94,8 @@ namespace vk {
             console_log_info("{} -- Swapchain out of date!! Attempting recreation.....", __FUNCTION__);
             m_resize_requested = true;
         }
+
+        m_wait_semaphore = VK_NULL_HANDLE;
     }
 
     void vk_queue::wait_idle() {
@@ -92,6 +104,7 @@ namespace vk {
 
     uint32_t vk_queue::read_acquire_image() {
         uint32_t image_acquired;
+
         VkResult acquired_next_image_result =
           vkAcquireNextImageKHR(m_driver,
                                 m_swapchain_handler,
@@ -99,7 +112,7 @@ namespace vk {
                                 m_present_completed_semaphore,
                                 nullptr,
                                 &image_acquired);
-        
+        m_wait_semaphore = m_present_completed_semaphore;
         m_status = acquired_next_image_result;
         if(acquired_next_image_result == VK_ERROR_OUT_OF_DATE_KHR) {
             console_log_info("{} -- Swapchain out of date!! Attempting recreation....", __FUNCTION__);

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -421,8 +421,7 @@ namespace vk {
 
 	void vk_swapchain::submit(const vk_command_buffer& p_current) {
 		m_swapchain_present_queue.submit_to(p_current,submission_type::Async);
-	}
-    
+	}  
 
 	void vk_swapchain::present() {
 		m_swapchain_present_queue.present(m_current_image_index);

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -310,6 +310,12 @@ namespace vk {
         console_log_info("Started: {}", __FUNCTION__);
         destroy();
         on_create();
+        
+        // invoke resize callbacks for any external resources that may depend on 
+        // the swapchain
+        for (auto & cb : m_resize_callbacks) {
+            cb(*this); // once again, there must be a more elegant way to pass this...
+        }
     }
 
     void vk_swapchain::create_new_framebuffers(const vk_renderpass& p_renderpass, std::span<VkFramebuffer> p_framebuffers, attachment_flags p_include_attachments) const {
@@ -468,5 +474,8 @@ namespace vk {
         m_swapchain_size.width = p_width;
         m_swapchain_size.height = p_height;
     }
-
+    
+    void vk_swapchain::register_resize_callback(resize_callback p_callback) {
+        m_resize_callbacks.push_back(std::move(p_callback));
+    }
 };

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -419,13 +419,10 @@ namespace vk {
 		return current_frame;
 	}
 
-	void vk_swapchain::submit(const VkCommandBuffer& p_current) {
+	void vk_swapchain::submit(const vk_command_buffer& p_current) {
 		m_swapchain_present_queue.submit_to(p_current,submission_type::Async);
 	}
     
-    void vk_swapchain::submit_sync(const VkCommandBuffer& p_current) {
-        m_swapchain_present_queue.submit_to(p_current, submission_type::Sync);
-    }
 
 	void vk_swapchain::present() {
 		m_swapchain_present_queue.present(m_current_image_index);

--- a/src/vulkan-cpp/vk_swapchain.cpp
+++ b/src/vulkan-cpp/vk_swapchain.cpp
@@ -301,17 +301,34 @@ namespace vk {
         // creating framebuffers
         m_swapchain_framebuffers.resize(m_swapchain_images.size());
 
+        create_new_framebuffers(m_swapchain_renderpass, m_swapchain_framebuffers);
+        console_log_info("vk_swapchain() successfully initialized!!!\n\n");
+    }
+
+    void vk_swapchain::recreate() {
+        vkDeviceWaitIdle(m_driver);
+        console_log_info("Started: {}", __FUNCTION__);
+        destroy();
+        on_create();
+    }
+
+    void vk_swapchain::create_new_framebuffers(const vk_renderpass& p_renderpass, std::span<VkFramebuffer> p_framebuffers, attachment_flags p_include_attachments) const {
+        if (p_include_attachments == 0) {
+            console_log_error("Framebuffers must include at least one attachment!");
+        }
         for (uint32_t i = 0; i < m_swapchain_images.size(); i++) {
             std::vector<VkImageView> image_view_attachments;
-            image_view_attachments.push_back(m_swapchain_images[i].ImageView);
-            image_view_attachments.push_back(
-              m_swapchain_depth_images[i].ImageView);
+
+            if (p_include_attachments & attachment_color) 
+                image_view_attachments.push_back(m_swapchain_images[i].ImageView);
+            if (p_include_attachments & attachment_depth)
+                image_view_attachments.push_back(m_swapchain_depth_images[i].ImageView);
 
             VkFramebufferCreateInfo framebuffer_ci = {
                 .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
                 .pNext = nullptr,
                 .flags = 0,
-                .renderPass = m_swapchain_renderpass,
+                .renderPass = p_renderpass,
                 // .attachmentCount = 1,
                 // .pAttachments = &m_swapchain_images[i].ImageView,
                 .attachmentCount =
@@ -325,19 +342,10 @@ namespace vk {
             vk_check(vkCreateFramebuffer(m_driver,
                                          &framebuffer_ci,
                                          nullptr,
-                                         &m_swapchain_framebuffers[i]),
+                                         &p_framebuffers[i]),
                      "vkCreateFramebuffer",
                      __FUNCTION__);
         }
-
-        console_log_info("vk_swapchain() successfully initialized!!!\n\n");
-    }
-
-    void vk_swapchain::recreate() {
-        vkDeviceWaitIdle(m_driver);
-        console_log_info("Started: {}", __FUNCTION__);
-        destroy();
-        on_create();
     }
 
 
@@ -414,6 +422,10 @@ namespace vk {
 	void vk_swapchain::submit(const VkCommandBuffer& p_current) {
 		m_swapchain_present_queue.submit_to(p_current,submission_type::Async);
 	}
+    
+    void vk_swapchain::submit_sync(const VkCommandBuffer& p_current) {
+        m_swapchain_present_queue.submit_to(p_current, submission_type::Sync);
+    }
 
 	void vk_swapchain::present() {
 		m_swapchain_present_queue.present(m_current_image_index);

--- a/vulkan-cpp/vk_command_buffer.hpp
+++ b/vulkan-cpp/vk_command_buffer.hpp
@@ -63,6 +63,9 @@ namespace vk {
             return (m_command_buffer_handler != nullptr);
         }
 
+        const VkSemaphore& get_finished_semaphore() const { return m_finished_semaphore; }
+        const VkSemaphore& get_finished_semaphore() { return m_finished_semaphore; }
+
         operator VkCommandBuffer() { return m_command_buffer_handler; }
         operator VkCommandBuffer() const { return m_command_buffer_handler; }
 
@@ -76,6 +79,8 @@ namespace vk {
         uint32_t m_begin_end_count = 0;
         VkCommandPool m_command_pool = nullptr;
         VkCommandBuffer m_command_buffer_handler = nullptr;
+        
+        VkSemaphore m_finished_semaphore = nullptr;
     };
 
 };

--- a/vulkan-cpp/vk_driver.hpp
+++ b/vulkan-cpp/vk_driver.hpp
@@ -16,6 +16,7 @@ namespace vk {
             VkQueue Compute;
         };
 
+
     public:
         vk_driver() = default;
         vk_driver(const vk_physical_driver& p_physical);
@@ -44,6 +45,12 @@ namespace vk {
 
         void destroy();
 
+
+        // NOTE:  Not const qualifiable at the moment due to
+        // querying queue family indices requiring a non-const 'this' binding
+        vk_physical_driver& get_physical_driver_context() {
+            return m_physical_driver;
+        }
     private:
         static vk_driver* s_instance;
         VkDevice m_driver = nullptr;
@@ -51,6 +58,5 @@ namespace vk {
         VkQueue m_graphics_queue = nullptr;
         device_queues m_device_queues;
 
-        queue_family_indices m_queue_indices;
     };
 };

--- a/vulkan-cpp/vk_imgui.hpp
+++ b/vulkan-cpp/vk_imgui.hpp
@@ -9,36 +9,43 @@
 namespace vk {
     class vk_imgui {
     public:
-        vk_imgui();
+	vk_imgui();
 
-        void initialize(const VkInstance& p_instance,
-                        const VkPhysicalDevice& p_physical, const VkRenderPass& p_rp, uint32_t p_image_size, const VkSurfaceFormatKHR& p_surface_format);
+	void initialize(const VkInstance& p_instance,
+			const VkPhysicalDevice& p_physical,
+			const VkSurfaceKHR& p_surface,
+			uint32_t p_image_size,
+			const VkSurfaceFormatKHR& p_surface_format,
+			const vk_swapchain& p_swapchain);
 
-        void begin();
-        void end(const VkCommandBuffer& p_current);
+	void begin();
 
-        void destroy();
+    // retrieves ImGUI draw data from declared UI components and 
+    // passes it to the vulkan implementation
+	void end(const VkCommandBuffer& p_current, vk_swapchain& p_swapchain);
 
+	void destroy();
 
     private:
-        void create_imgui_renderpass();
-        void create_imgui_framebuffers();
-        void create_viewport_images();
-        void create_viewport_imageview();
+	void create_imgui_renderpass();
+	void create_imgui_framebuffers();
+	void create_viewport_images();
+	void create_viewport_imageview();
 
     private:
-        vk_driver m_driver;
-        VkDescriptorPool m_imgui_desc_pool = nullptr;
-        VkCommandPool m_imgui_command_pool=nullptr;
+	vk_driver m_driver;
+	VkDescriptorPool m_imgui_desc_pool = nullptr;
+	VkCommandPool m_imgui_command_pool = nullptr;
 
-        std::vector<vk_image> m_viewport_images;
-        std::vector<VkFramebuffer> m_viewport_framebuffers;
+	std::vector<vk_image> m_viewport_images;
+	std::vector<VkFramebuffer> m_viewport_framebuffers;
 
-        vk_renderpass m_imgui_renderpass;
-        // vk_swapchain m_current_swapchain;
-        // VkRenderPass m_viewport_renderpass=nullptr;
+	vk_renderpass m_imgui_renderpass;
+	vk_command_buffer m_command_buffer;
+	// vk_swapchain m_current_swapchain;
+	// VkRenderPass m_viewport_renderpass=nullptr;
 
-        // std::vector<VkImage> m_viewport_images;
-        // std::vector<VkImageView>
+	// std::vector<VkImage> m_viewport_images;
+	// std::vector<VkImageView>
     };
 };

--- a/vulkan-cpp/vk_imgui.hpp
+++ b/vulkan-cpp/vk_imgui.hpp
@@ -32,6 +32,8 @@ namespace vk {
 	void create_viewport_images();
 	void create_viewport_imageview();
 
+    void on_resize(const vk_swapchain& p_swapchain);
+
     private:
 	vk_driver m_driver;
 	VkDescriptorPool m_imgui_desc_pool = nullptr;

--- a/vulkan-cpp/vk_imgui.hpp
+++ b/vulkan-cpp/vk_imgui.hpp
@@ -16,7 +16,7 @@ namespace vk {
 			const VkSurfaceKHR& p_surface,
 			uint32_t p_image_size,
 			const VkSurfaceFormatKHR& p_surface_format,
-			const vk_swapchain& p_swapchain);
+			vk_swapchain& p_swapchain);
 
 	void begin();
 

--- a/vulkan-cpp/vk_imgui.hpp
+++ b/vulkan-cpp/vk_imgui.hpp
@@ -4,6 +4,7 @@
 #include <vulkan-cpp/vk_driver.hpp>
 #include <vulkan-cpp/vk_buffer.hpp>
 #include <vulkan-cpp/vk_swapchain.hpp>
+#include <vulkan-cpp/vk_renderpass.hpp>
 
 namespace vk {
     class vk_imgui {
@@ -32,7 +33,8 @@ namespace vk {
 
         std::vector<vk_image> m_viewport_images;
         std::vector<VkFramebuffer> m_viewport_framebuffers;
-        VkRenderPass m_imgui_renderpass=nullptr;
+
+        vk_renderpass m_imgui_renderpass;
         // vk_swapchain m_current_swapchain;
         // VkRenderPass m_viewport_renderpass=nullptr;
 

--- a/vulkan-cpp/vk_queue.hpp
+++ b/vulkan-cpp/vk_queue.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <vulkan/vulkan.hpp>
 #include <vulkan-cpp/vk_driver.hpp>
+#include <vulkan-cpp/vk_command_buffer.hpp>
 
 namespace vk {
     enum class submission_type { Sync = 0, Async = 1 };
@@ -28,7 +29,7 @@ namespace vk {
         Specify whether you want to submit to the command buffer in either async
         or synchronization mode
         */
-        void submit_to(const VkCommandBuffer& p_command_buffer,
+        void submit_to(const vk_command_buffer& p_command_buffer,
                        submission_type submission_t);
 
         void present(uint32_t p_frame_index);
@@ -40,7 +41,6 @@ namespace vk {
         operator VkQueue() const { return m_queue; }
 
     private:
-    private:
         // void wait_active_semaphores();
 
         vk_driver m_driver;
@@ -51,7 +51,7 @@ namespace vk {
         bool m_resize_requested=false;
         VkResult m_status;
 
-        // VkSemaphore m_wait_semaphore = nullptr;
-        // VkSemaphore m_signal_semaphore = nullptr;
+        VkSemaphore m_wait_semaphore = nullptr;
+        VkSemaphore m_signal_semaphore = nullptr;
     };
 };

--- a/vulkan-cpp/vk_queue.hpp
+++ b/vulkan-cpp/vk_queue.hpp
@@ -41,6 +41,8 @@ namespace vk {
 
     private:
     private:
+        // void wait_active_semaphores();
+
         vk_driver m_driver;
         VkSwapchainKHR m_swapchain_handler = nullptr;
         VkQueue m_queue = nullptr;
@@ -48,5 +50,8 @@ namespace vk {
         VkSemaphore m_present_completed_semaphore;
         bool m_resize_requested=false;
         VkResult m_status;
+
+        // VkSemaphore m_wait_semaphore = nullptr;
+        // VkSemaphore m_signal_semaphore = nullptr;
     };
 };

--- a/vulkan-cpp/vk_swapchain.hpp
+++ b/vulkan-cpp/vk_swapchain.hpp
@@ -18,6 +18,10 @@ namespace vk {
         attachment_depth = 0b10,
         attachments_all = 0b11,
     };
+    
+    class vk_swapchain;
+
+    using resize_callback = std::function<void(const vk_swapchain&)>;
 
     class vk_swapchain {
     public:
@@ -43,6 +47,8 @@ namespace vk {
 
         // Yuckified this functions signature since certain framebuffers only need certain attachments
         void create_new_framebuffers(const vk_renderpass& p_renderpass, std::span<VkFramebuffer> p_frame_buffers, attachment_flags p_include_attachments = attachments_all) const;
+
+        void register_resize_callback(resize_callback p_callback);
 
         /*
         //! @note This is something to do once we cleanup the swapchain
@@ -87,6 +93,8 @@ namespace vk {
     private:
         // change swapchain background color
         VkClearColorValue m_color = { 0.5f, 0.5f, 0.5f, 0.f };
+        
+        std::vector<resize_callback> m_resize_callbacks{};
 
     private:
         static vk_swapchain* s_instance;

--- a/vulkan-cpp/vk_swapchain.hpp
+++ b/vulkan-cpp/vk_swapchain.hpp
@@ -12,6 +12,13 @@ namespace vk {
     struct swapchain_configs {
         static constexpr uint32_t MaxFramesInFlight = 3;
     };
+
+    enum attachment_flags : uint8_t {
+        attachment_color = 0b1,
+        attachment_depth = 0b10,
+        attachments_all = 0b11,
+    };
+
     class vk_swapchain {
     public:
         vk_swapchain() = default;
@@ -30,9 +37,13 @@ namespace vk {
         void end(vk_command_buffer& p_current);
 
         void submit(const VkCommandBuffer& p_current);
+        void submit_sync(const VkCommandBuffer& p_current);
         void present();
 
         vk_command_buffer get_active_command_buffer(uint32_t p_frame) { return m_swapchain_command_buffers[p_frame]; }
+
+        // Yuckified this functions signature since certain framebuffers only need certain attachments
+        void create_new_framebuffers(const vk_renderpass& p_renderpass, std::span<VkFramebuffer> p_frame_buffers, attachment_flags p_include_attachments = attachments_all) const;
 
         /*
         //! @note This is something to do once we cleanup the swapchain
@@ -69,10 +80,6 @@ namespace vk {
         }
 
         surface_properties data() const { return m_surface_data; }
-
-        static uint32_t image_count() {
-            return s_instance->m_swapchain_images.size();
-        }
 
     private:
         //! @note These private functions are for initiating the swapchain first

--- a/vulkan-cpp/vk_swapchain.hpp
+++ b/vulkan-cpp/vk_swapchain.hpp
@@ -36,8 +36,7 @@ namespace vk {
         void begin(vk_command_buffer& p_current);
         void end(vk_command_buffer& p_current);
 
-        void submit(const VkCommandBuffer& p_current);
-        void submit_sync(const VkCommandBuffer& p_current);
+        void submit(const vk_command_buffer& p_current);
         void present();
 
         vk_command_buffer get_active_command_buffer(uint32_t p_frame) { return m_swapchain_command_buffers[p_frame]; }


### PR DESCRIPTION
## Brief
Mostly revamped the vulkan imgui integration so that it shared less state with the rest of the rendering pipeline (as many of the general render states are incompatible with an ImGUi implementation). Additionally , I also refactored the underlying functionality of the queues and command buffers to better support GPU synchronization when using multiple independent command buffer submissions per frame.

## Changelog
* Integrated vk_renderpass into imgui (via giving imgui a separate renderpass and such)
* Implemented a unique viewport for the imgui implementation
* Implemented a new command buffer synchronization mechanism to better support multiple independent submissions
* Fixed imgui renderpass expected image formatting issue by introducing a present->color->present format transition cycle
* Introduced a simple on_resize callback handler for the swapchain so dependent resources can automatically be reloaded on a resize.